### PR TITLE
Fix: Render image now persists even if the windows is minimized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/02/09 15:25:00 by lfarias-          #+#    #+#              #
-#    Updated: 2023/04/09 14:51:30 by gcorreia         ###   ########.fr        #
+#    Updated: 2023/04/10 12:29:43 by lfarias-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -54,6 +54,7 @@ RENDER = $(addprefix render/,	\
 	cylinder_intersection.c 	\
 	cone_intersection.c			\
 	render_scene.c				\
+	render_loop.c				\
 	get_px_color.c				\
 	compute_diffuse.c			\
 	compute_ambient.c			\

--- a/headers/render.h
+++ b/headers/render.h
@@ -6,7 +6,7 @@
 /*   By: gcorreia <gcorreia@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/10 17:55:27 by gcorreia          #+#    #+#             */
-/*   Updated: 2023/04/09 14:06:07 by gcorreia         ###   ########.fr       */
+/*   Updated: 2023/04/10 12:26:38 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 
 void			render_scene(t_scene *scene, t_window *win);
 void			interactive_render(t_scene *scene, t_window *win);
+int				render_loop(void *param);
 
 /* ************************************************************************** */
 

--- a/headers/types.h
+++ b/headers/types.h
@@ -6,7 +6,7 @@
 /*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/09 15:26:53 by lfarias-          #+#    #+#             */
-/*   Updated: 2023/04/07 19:07:27 by lfarias-         ###   ########.fr       */
+/*   Updated: 2023/04/10 14:37:50 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -162,6 +162,7 @@ typedef struct s_window
 	t_vars	vars;
 	int		height;
 	int		width;
+	char	*menu_img_path;
 }				t_window;
 
 typedef struct s_info

--- a/sources/mlx/initialization.c
+++ b/sources/mlx/initialization.c
@@ -6,7 +6,7 @@
 /*   By: gcorreia <gcorreia@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/14 10:38:29 by gcorreia          #+#    #+#             */
-/*   Updated: 2023/03/29 11:52:33 by gcorreia         ###   ########.fr       */
+/*   Updated: 2023/04/10 12:27:58 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,7 @@ static void	init_vars(t_info *info)
 			info->w->height, "MiniRT");
 	mlx_hook(info->w->vars.win, 2, 1L << 0, handle_keypress, info);
 	mlx_hook(info->w->vars.win, 17, 0L << 0, handle_destroy, info);
+	mlx_loop_hook(info->w->vars.mlx, render_loop, info);
 }
 
 static void	init_image(t_window *win)

--- a/sources/render/interactive_render.c
+++ b/sources/render/interactive_render.c
@@ -6,7 +6,7 @@
 /*   By: gcorreia <gcorreia@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/20 16:15:36 by gcorreia          #+#    #+#             */
-/*   Updated: 2023/04/09 14:32:58 by gcorreia         ###   ########.fr       */
+/*   Updated: 2023/04/10 14:38:04 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,6 @@ void	interactive_render(t_scene *scene, t_window *win)
 {
 	int		x;
 	int		y;
-	void	*menu;
 
 	x = 0;
 	while (x < win->width)
@@ -32,11 +31,7 @@ void	interactive_render(t_scene *scene, t_window *win)
 		}
 		++x;
 	}
-	menu = mlx_xpm_file_to_image(win->vars.mlx, "images/Interactive_menu.xpm",
-			&x, &y);
-	mlx_put_image_to_window(win->vars.mlx, win->vars.win, win->image.img, 0, 0);
-	mlx_put_image_to_window(win->vars.mlx, win->vars.win, menu, 0, 0);
-	mlx_destroy_image(win->vars.mlx, menu);
+	win->menu_img_path = "images/Interactive_menu.xpm";
 }
 
 static void	render_px(int x, int y, t_scene *s, t_window *win)

--- a/sources/render/render_loop.c
+++ b/sources/render/render_loop.c
@@ -1,0 +1,29 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   render_loop.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lfarias- <lfarias-@student.42.rio>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/04/10 12:07:59 by lfarias-          #+#    #+#             */
+/*   Updated: 2023/04/10 14:38:13 by lfarias-         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../headers/mini_rt.h"
+
+int	render_loop(void *param)
+{
+	t_info	*info;
+	void	*menu;
+	int		x;
+	int		y;
+
+	info = (t_info *) param;
+	menu = mlx_xpm_file_to_image(info->w->vars.mlx, info->w->menu_img_path,
+			&x, &y);
+	mlx_put_image_to_window(info->w->vars.mlx, info->w->vars.win, info->w->image.img, 0, 0);
+	mlx_put_image_to_window(info->w->vars.mlx, info->w->vars.win, menu, 0, 0);
+	mlx_destroy_image(info->w->vars.mlx, menu);
+	return (0);
+}

--- a/sources/render/render_scene.c
+++ b/sources/render/render_scene.c
@@ -6,7 +6,7 @@
 /*   By: gcorreia <gcorreia@student.42.rio>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/20 16:15:36 by gcorreia          #+#    #+#             */
-/*   Updated: 2023/04/09 14:30:36 by gcorreia         ###   ########.fr       */
+/*   Updated: 2023/04/10 14:37:55 by lfarias-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,6 @@ void	render_scene(t_scene *scene, t_window *win)
 {
 	int		x;
 	int		y;
-	void	*menu;
 
 	x = 0;
 	while (x < win->width)
@@ -32,11 +31,7 @@ void	render_scene(t_scene *scene, t_window *win)
 		}
 		++x;
 	}
-	menu = mlx_xpm_file_to_image(win->vars.mlx, "images/Render_menu.xpm",
-			&x, &y);
-	mlx_put_image_to_window(win->vars.mlx, win->vars.win, win->image.img, 0, 0);
-	mlx_put_image_to_window(win->vars.mlx, win->vars.win, menu, 0, 0);
-	mlx_destroy_image(win->vars.mlx, menu);
+	win->menu_img_path = "images/Render_menu.xpm";
 }
 
 static void	render_px(int x, int y, t_scene *s, t_window *win)


### PR DESCRIPTION
I don't know the nitty-gritty details behind how mlx works but the fix for the problem of the image sent to the window disappearing when you maximize the application later in time is:

For every frame the mlx produces we want it to keep displaying the rendered image until there's a change (i.e when it enters or exits the interactive mode)

To achieve that, now render_scene and interactive_render only deal with the logic to render the image. the mlx display logic is now encapsulated inside render_loop which is a function that is called by mlx_loop_hook.
To deal with the menu images, the window has now a `menu_img_path` attribute that is set by render_loop and interactive_render. This attribute is used by our render_loop function to render the appropriate menu.

notes: It's the same fix I made for my FDF project, but I still recommend we give special attention to it when running the miniRT on a mac.